### PR TITLE
디스코드 알람 전송 기능 구현

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module themoment-team/hellogsm-notice-server
+
+go 1.19
+
+require github.com/joho/godotenv v1.5.1

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
+github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=

--- a/main.go
+++ b/main.go
@@ -14,7 +14,7 @@ import (
 
 var discordWebhookURL string
 
-func sendNoticeToDiscord(notification Notification) error {
+func sendNoticeToDiscord(notification HellogsmNotification) error {
 	embed := Embed{
 		Title:       notification.Title,
 		Description: notification.Content,
@@ -55,7 +55,7 @@ func handler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var notification Notification
+	var notification HellogsmNotification
 	if err := json.NewDecoder(r.Body).Decode(&notification); err != nil {
 		http.Error(w, "JSON 파싱 실패", http.StatusBadRequest)
 		return

--- a/main.go
+++ b/main.go
@@ -18,7 +18,7 @@ func sendToDiscordWebhook(notification Notification) error {
 	embed := Embed{
 		Title:       notification.Title,
 		Description: notification.Content,
-		Color:       notification.Status.getColorCode(),
+		Color:       notification.NoticeLevel.getColorCode(),
 	}
 
 	payload := DiscordWebhookPayload{
@@ -61,8 +61,8 @@ func handler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if !notification.Status.validStatus() {
-		http.Error(w, fmt.Sprintf("잘못된 Status: %s", notification.Status), http.StatusBadRequest)
+	if !notification.NoticeLevel.validNoticeLevel() {
+		http.Error(w, fmt.Sprintf("잘못된 NoticeLevel: %s", notification.NoticeLevel), http.StatusBadRequest)
 		return
 	}
 

--- a/main.go
+++ b/main.go
@@ -84,7 +84,7 @@ func main() {
 
 	http.HandleFunc("/notice", handler)
 
-	if err := http.ListenAndServe(":8080", nil); err != nil {
+	if err := http.ListenAndServe(":8085", nil); err != nil {
 		panic(err)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+
+	"github.com/joho/godotenv"
+)
+
+var discordWebhookURL string
+
+func sendToDiscordWebhook(notification Notification) error {
+	embed := Embed{
+		Title:       notification.Title,
+		Description: notification.Content,
+		Color:       notification.Status.getColorCode(),
+	}
+
+	payload := DiscordWebhookPayload{
+		Embeds:  []Embed{embed},
+		Content: "@everyone",
+	}
+
+	payloadBytes, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("payload 변환 실패: %w", err)
+	}
+
+	res, err := http.Post(discordWebhookURL, "application/json", bytes.NewReader(payloadBytes))
+	if err != nil {
+		return fmt.Errorf("HTTP 요청 실패: %w", err)
+	}
+
+	if res.StatusCode != http.StatusOK && res.StatusCode != http.StatusNoContent {
+		defer res.Body.Close()
+
+		body, err := io.ReadAll(res.Body)
+		if err != nil {
+			return fmt.Errorf("디스코드 웹훅 응답 오류: %s. 처리 중 응답 읽기 실패: %w", res.Status, err)
+		}
+
+		return fmt.Errorf("디스코드 웹훅 응답 오류: %s - %s", res.Status, body)
+	}
+
+	return nil
+}
+
+func handler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "지원되지 않는 메서드", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var notification Notification
+	if err := json.NewDecoder(r.Body).Decode(&notification); err != nil {
+		http.Error(w, "JSON 파싱 실패", http.StatusBadRequest)
+		return
+	}
+
+	if !notification.Status.validStatus() {
+		http.Error(w, fmt.Sprintf("잘못된 Status: %s", notification.Status), http.StatusBadRequest)
+		return
+	}
+
+	if err := sendToDiscordWebhook(notification); err != nil {
+		log.Println("디스코드 웹훅 전송 실패", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusCreated)
+}
+
+func main() {
+	err := godotenv.Load()
+	if err != nil {
+		panic(err)
+	}
+	discordWebhookURL = os.Getenv("DISCORD_WEBHOOK_URL")
+
+	http.HandleFunc("/notice", handler)
+
+	if err := http.ListenAndServe(":8080", nil); err != nil {
+		panic(err)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -14,7 +14,7 @@ import (
 
 var discordWebhookURL string
 
-func sendNoticeToDiscord(notification HellogsmNotification) error {
+func sendNotificationToDiscord(notification HellogsmNotification) error {
 	embed := Embed{
 		Title:       notification.Title,
 		Description: notification.Content,
@@ -66,7 +66,7 @@ func handler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := sendNoticeToDiscord(notification); err != nil {
+	if err := sendNotificationToDiscord(notification); err != nil {
 		log.Println("디스코드 웹훅 전송 실패", err)
 		w.WriteHeader(http.StatusInternalServerError)
 		return

--- a/main.go
+++ b/main.go
@@ -14,7 +14,7 @@ import (
 
 var discordWebhookURL string
 
-func sendToDiscordWebhook(notification Notification) error {
+func sendNoticeToDiscord(notification Notification) error {
 	embed := Embed{
 		Title:       notification.Title,
 		Description: notification.Content,
@@ -66,7 +66,7 @@ func handler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := sendToDiscordWebhook(notification); err != nil {
+	if err := sendNoticeToDiscord(notification); err != nil {
 		log.Println("디스코드 웹훅 전송 실패", err)
 		w.WriteHeader(http.StatusInternalServerError)
 		return

--- a/main.go
+++ b/main.go
@@ -61,7 +61,7 @@ func handler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if !notification.NoticeLevel.validNoticeLevel() {
+	if !notification.NoticeLevel.isValidNoticeLevel() {
 		http.Error(w, fmt.Sprintf("잘못된 NoticeLevel: %s", notification.NoticeLevel), http.StatusBadRequest)
 		return
 	}

--- a/main.go
+++ b/main.go
@@ -22,8 +22,7 @@ func sendToDiscordWebhook(notification Notification) error {
 	}
 
 	payload := DiscordWebhookPayload{
-		Embeds:  []Embed{embed},
-		Content: "@everyone",
+		Embeds: []Embed{embed},
 	}
 
 	payloadBytes, err := json.Marshal(payload)

--- a/types.go
+++ b/types.go
@@ -39,7 +39,7 @@ type DiscordWebhookPayload struct {
 	Embeds []Embed `json:"embeds"`
 }
 
-type Notification struct {
+type HellogsmNotification struct {
 	Title       string      `json:"title"`
 	Content     string      `json:"content"`
 	NoticeLevel NoticeLevel `json:"noticeLevel"`

--- a/types.go
+++ b/types.go
@@ -1,0 +1,47 @@
+package main
+
+type Status string
+
+const (
+	StatusError Status = "error"
+	StatusWarn  Status = "warn"
+	StatusInfo  Status = "info"
+)
+
+func (s Status) getColorCode() int {
+	switch s {
+	case StatusError:
+		return 0xFF4C4C
+	case StatusWarn:
+		return 0xFFA500
+	case StatusInfo:
+		return 0x4CAF50
+	}
+
+	return -1
+}
+
+func (s Status) validStatus() bool {
+	switch s {
+	case StatusError, StatusWarn, StatusInfo:
+		return true
+	}
+	return false
+}
+
+type Embed struct {
+	Title       string `json:"title"`
+	Description string `json:"description"`
+	Color       int    `json:"color,omitempty"`
+}
+
+type DiscordWebhookPayload struct {
+	Embeds  []Embed `json:"embeds"`
+	Content string  `json:"content"`
+}
+
+type Notification struct {
+	Title   string `json:"title"`
+	Content string `json:"content"`
+	Status  Status `json:"status"`
+}

--- a/types.go
+++ b/types.go
@@ -16,9 +16,9 @@ func (s NoticeLevel) getColorCode() int {
 		return 0xFFA500
 	case NoticeLevelInfo:
 		return 0x4CAF50
+	default:
+		return -1
 	}
-
-	return -1
 }
 
 func (s NoticeLevel) validNoticeLevel() bool {

--- a/types.go
+++ b/types.go
@@ -21,7 +21,7 @@ func (s NoticeLevel) getColorCode() int {
 	}
 }
 
-func (s NoticeLevel) validNoticeLevel() bool {
+func (s NoticeLevel) isValidNoticeLevel() bool {
 	switch s {
 	case NoticeLevelError, NoticeLevelWarn, NoticeLevelInfo:
 		return true

--- a/types.go
+++ b/types.go
@@ -1,29 +1,29 @@
 package main
 
-type Status string
+type NoticeLevel string
 
 const (
-	StatusError Status = "error"
-	StatusWarn  Status = "warn"
-	StatusInfo  Status = "info"
+	NoticeLevelError NoticeLevel = "error"
+	NoticeLevelWarn  NoticeLevel = "warn"
+	NoticeLevelInfo  NoticeLevel = "info"
 )
 
-func (s Status) getColorCode() int {
+func (s NoticeLevel) getColorCode() int {
 	switch s {
-	case StatusError:
+	case NoticeLevelError:
 		return 0xFF4C4C
-	case StatusWarn:
+	case NoticeLevelWarn:
 		return 0xFFA500
-	case StatusInfo:
+	case NoticeLevelInfo:
 		return 0x4CAF50
 	}
 
 	return -1
 }
 
-func (s Status) validStatus() bool {
+func (s NoticeLevel) validNoticeLevel() bool {
 	switch s {
-	case StatusError, StatusWarn, StatusInfo:
+	case NoticeLevelError, NoticeLevelWarn, NoticeLevelInfo:
 		return true
 	}
 	return false
@@ -40,7 +40,7 @@ type DiscordWebhookPayload struct {
 }
 
 type Notification struct {
-	Title   string `json:"title"`
-	Content string `json:"content"`
-	Status  Status `json:"status"`
+	Title       string      `json:"title"`
+	Content     string      `json:"content"`
+	NoticeLevel NoticeLevel `json:"noticeLevel"`
 }

--- a/types.go
+++ b/types.go
@@ -36,8 +36,7 @@ type Embed struct {
 }
 
 type DiscordWebhookPayload struct {
-	Embeds  []Embed `json:"embeds"`
-	Content string  `json:"content"`
+	Embeds []Embed `json:"embeds"`
 }
 
 type Notification struct {


### PR DESCRIPTION
## 개요

HTTP endpoint를 추가하여 특정 알림을 디스코드 웹훅으로 전송하는 기능을 구현하였습니다. 
이를 통해 외부 시스템에서 발생한 이벤트를 디스코드 채널에 실시간으로 알릴 수 있습니다.

<br>

## 작업 내용

- HTTP `POST /notice` endpoint를 통해 요청을 처리
- request data를 파싱하여 디스코드 웹훅으로 메시지 전송

<img width="276" alt="image" src="https://github.com/user-attachments/assets/467d06c8-2e3f-4b3c-b8f8-89af4e70de03">


<br>

## 피드백

- 현재는 discord metion하는 기능은 제외하였는데, 필요할지 의견 부탁드립니다.
- go 사용이 처음이라 부족한 부분이 많을 거 같습니다. 편하게 피드백 부탁드립니다.