### PR TITLE
1차 배치 이전 base data dml이 아닐때 정원외특별전형은 최대 3명까지로 고정

### DIFF
--- a/cmd/generate-dml/generate-oneseo.go
+++ b/cmd/generate-dml/generate-oneseo.go
@@ -17,14 +17,32 @@ func GenerateOneseoInsertQuery(rows int, initialScreening _type.Screening, onese
 		_type.EXTRA_VETERANS,
 	}
 
-	buffer.WriteString("-- tb_oneseo" + "\n\n")
+	extraAdmissionCount := 0
+	extraVeteransCount := 0
 
 	for i := 1; i <= rows; i++ {
-
-		// Screening이 RANDOM 이라면 GENERAL, SPECIAL, EXTRA_ADMISSION, EXTRA_VETERANS 중 하나로 랜덤 배정
 		screening := initialScreening
 		if screening == _type.RANDOM_SCREENING {
-			screening = allScreenings[rand.Intn(len(allScreenings))]
+			if oneseoStatus != _type.FIRST {
+				validScreenings := []_type.Screening{}
+
+				if extraAdmissionCount+extraVeteransCount < 3 {
+					validScreenings = append(validScreenings, _type.EXTRA_ADMISSION, _type.EXTRA_VETERANS)
+				}
+
+				validScreenings = append(validScreenings, _type.GENERAL, _type.SPECIAL)
+
+				screening = validScreenings[rand.Intn(len(validScreenings))]
+
+				switch screening {
+				case _type.EXTRA_ADMISSION:
+					extraAdmissionCount++
+				case _type.EXTRA_VETERANS:
+					extraVeteransCount++
+				}
+			} else {
+				screening = allScreenings[rand.Intn(len(allScreenings))]
+			}
 		}
 
 		// submitCodePrefix는 GENERAL - A, SPECIAL - B, EXTRA_ADMISSION, EXTRA_VETERANS - C


### PR DESCRIPTION
## 개요
1차 배치 이후에는 정원외특별전형의 지원자가 최대 3명까지 뽑히기 때문에, 1차 배치 이전에 필요한 base data (status FIRST)가 아닐때는 정원외특별전형 screening은 최대 3번 할당되도록 설정하였습니다.