### PR TITLE
실제로 내부 운영 보조 역할을 수행하도록 기능을 추가 함.

### DIFF
--- a/cmd/notice-server/main.go
+++ b/cmd/notice-server/main.go
@@ -4,15 +4,64 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"github.com/joho/godotenv"
 	"io"
 	"log"
 	"net/http"
 	"os"
-
-	"github.com/joho/godotenv"
 )
 
 var discordWebhookURL string
+
+func main() {
+	err := godotenv.Load()
+	if err != nil {
+		panic(err)
+	}
+	discordWebhookURL = os.Getenv("DISCORD_WEBHOOK_URL")
+
+	http.HandleFunc("/notice", handleDiscordWebhook)
+	http.HandleFunc("/ping", handlePing)
+
+	if err := http.ListenAndServe(":8085", logRequest(http.DefaultServeMux)); err != nil {
+		panic(err)
+	}
+}
+
+// 더모먼트팀 discord 채널로 메시지를 서빙한다.
+func handleDiscordWebhook(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "지원되지 않는 메서드", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var notification HellogsmNotification
+	if err := json.NewDecoder(r.Body).Decode(&notification); err != nil {
+		http.Error(w, "JSON 파싱 실패", http.StatusBadRequest)
+		return
+	}
+
+	if !notification.NoticeLevel.isValidNoticeLevel() {
+		http.Error(w, fmt.Sprintf("잘못된 NoticeLevel: %s", notification.NoticeLevel), http.StatusBadRequest)
+		return
+	}
+
+	if err := sendNotificationToDiscord(notification); err != nil {
+		log.Println("디스코드 웹훅 전송 실패", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusCreated)
+}
+
+// ALB 등에서 health check 를 위한 endpoint 를 만든다.
+func handlePing(writer http.ResponseWriter, request *http.Request) {
+	if request.Method != http.MethodGet {
+		http.Error(writer, "지원하지 않는 메소드", http.StatusMethodNotAllowed)
+	}
+	writer.WriteHeader(http.StatusOK)
+}
 
 func sendNotificationToDiscord(notification HellogsmNotification) error {
 	embed := Embed{
@@ -49,42 +98,10 @@ func sendNotificationToDiscord(notification HellogsmNotification) error {
 	return nil
 }
 
-func handler(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodPost {
-		http.Error(w, "지원되지 않는 메서드", http.StatusMethodNotAllowed)
-		return
-	}
-
-	var notification HellogsmNotification
-	if err := json.NewDecoder(r.Body).Decode(&notification); err != nil {
-		http.Error(w, "JSON 파싱 실패", http.StatusBadRequest)
-		return
-	}
-
-	if !notification.NoticeLevel.isValidNoticeLevel() {
-		http.Error(w, fmt.Sprintf("잘못된 NoticeLevel: %s", notification.NoticeLevel), http.StatusBadRequest)
-		return
-	}
-
-	if err := sendNotificationToDiscord(notification); err != nil {
-		log.Println("디스코드 웹훅 전송 실패", err)
-		w.WriteHeader(http.StatusInternalServerError)
-		return
-	}
-
-	w.WriteHeader(http.StatusCreated)
-}
-
-func main() {
-	err := godotenv.Load()
-	if err != nil {
-		panic(err)
-	}
-	discordWebhookURL = os.Getenv("DISCORD_WEBHOOK_URL")
-
-	http.HandleFunc("/notice", handler)
-
-	if err := http.ListenAndServe(":8085", nil); err != nil {
-		panic(err)
-	}
+// handleDiscordWebhook, handlePing 모두 client 에서 http status code 만으로 성공, 실패 여부를 확인 가능하기에, request 만 로깅한다.
+func logRequest(handler http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		log.Printf("%s %s %s\n", r.RemoteAddr, r.Method, r.URL)
+		handler.ServeHTTP(w, r)
+	})
 }

--- a/go.mod
+++ b/go.mod
@@ -4,4 +4,4 @@ go 1.19
 
 require github.com/joho/godotenv v1.5.1
 
-require github.com/google/uuid v1.6.0 // indirect
+require github.com/google/uuid v1.6.0

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module themoment-team/hellogsm-notice-server
+module themoment-team/go-hellogsm-ops
 
 go 1.19
 


### PR DESCRIPTION
## 작업한 내용

1. private API 에 대해서 열려있던 부분을 ACL(x-hg-api-key)을 적용하여 무분별한 클라이언트 사용을 제한 함.
2. request 를 logging 하도록 함.
3. go api server 가 graceful shutdown 하도록 기능을 추가 함.