### PR TITLE
refactor: 역량검사로 인한 테이블 column명 변경 반영

### DIFF
--- a/cmd/generate-dml/generate-entrance-test-result.go
+++ b/cmd/generate-dml/generate-entrance-test-result.go
@@ -11,7 +11,7 @@ func GenerateEntranceTestResultInsertQuery(rows int, oneseoStatus OneseoStatus, 
 	buffer.WriteString("-- tb_entrance_test_result_insert" + "\n\n")
 
 	for i := 1; i <= rows; i++ {
-		var aptitudeEvaluationScore, interviewScore *float64
+		var competencyEvaluationScore, interviewScore *float64
 		var documentEvaluationScore float64
 		var firstTestPassYn, secondTestPassYn *string
 
@@ -20,36 +20,36 @@ func GenerateEntranceTestResultInsertQuery(rows int, oneseoStatus OneseoStatus, 
 
 		switch oneseoStatus {
 		case FIRST:
-			aptitudeEvaluationScore = nil
+			competencyEvaluationScore = nil
 			interviewScore = nil
 			firstTestPassYn = nil
 			secondTestPassYn = nil
 
 		case SECOND:
-			aptitudeEvaluationScoreValue := randomFloat(0, 100)
+			competencyEvaluationScoreValue := randomFloat(0, 100)
 			interviewScoreValue := randomFloat(0, 100)
 
-			aptitudeEvaluationScore = &aptitudeEvaluationScoreValue
+			competencyEvaluationScore = &competencyEvaluationScoreValue
 			interviewScore = &interviewScoreValue
 
 			firstTestPassYn = stringPointer("YES")
 			secondTestPassYn = nil
 
 		case FINAL_MAJOR:
-			aptitudeEvaluationScoreValue := randomFloat(0, 100)
+			competencyEvaluationScoreValue := randomFloat(0, 100)
 			interviewScoreValue := randomFloat(0, 100)
 
-			aptitudeEvaluationScore = &aptitudeEvaluationScoreValue
+			competencyEvaluationScore = &competencyEvaluationScoreValue
 			interviewScore = &interviewScoreValue
 
 			firstTestPassYn = stringPointer("YES")
 			secondTestPassYn = stringPointer("YES")
 
 		case RE_EVALUATE:
-			aptitudeEvaluationScoreValue := randomFloat(0, 100)
+			competencyEvaluationScoreValue := randomFloat(0, 100)
 			interviewScoreValue := randomFloat(0, 100)
 
-			aptitudeEvaluationScore = &aptitudeEvaluationScoreValue
+			competencyEvaluationScore = &competencyEvaluationScoreValue
 			interviewScore = &interviewScoreValue
 
 			firstTestPassYn = stringPointer("YES")
@@ -57,9 +57,9 @@ func GenerateEntranceTestResultInsertQuery(rows int, oneseoStatus OneseoStatus, 
 		}
 
 		query := fmt.Sprintf(
-			"INSERT INTO tb_entrance_test_result (aptitude_evaluation_score, document_evaluation_score, interview_score, entrance_test_factors_detail_id, oneseo_id, first_test_pass_yn, second_test_pass_yn) "+
+			"INSERT INTO tb_entrance_test_result (competency_evaluation_score, document_evaluation_score, interview_score, entrance_test_factors_detail_id, oneseo_id, first_test_pass_yn, second_test_pass_yn) "+
 				"VALUES (%s, %.2f, %s, %d, %d, %s, %s);",
-			formatNullable(aptitudeEvaluationScore),
+			formatNullable(competencyEvaluationScore),
 			documentEvaluationScore,
 			formatNullable(interviewScore),
 			i,


### PR DESCRIPTION
2차 적성검사가 역량검사로 변경됨에 따라 아래 PR에서 `tb_entrance_test_result`의 적성검사 column명이 `aptitude_evaluation_score`에서 `competency_evaluation_score`로 변경되었습니다.
https://github.com/themoment-team/hellogsm-server-24/pull/233

dml generator의 코드를 변경하여 이를 반영했습니다.