### PR TITLE
update: 기존 실수형 점수들을 소수점 셋째 자리까지 나타내는 점수를 생성하도록 변경

### DIFF
--- a/cmd/generate-dml/generate-entrance-test-result.go
+++ b/cmd/generate-dml/generate-entrance-test-result.go
@@ -26,31 +26,22 @@ func GenerateEntranceTestResultInsertQuery(rows int, oneseoStatus OneseoStatus, 
 			secondTestPassYn = nil
 
 		case SECOND:
-			competencyEvaluationScoreValue := randomFloat(0, 100)
-			interviewScoreValue := randomFloat(0, 100)
-
-			competencyEvaluationScore = &competencyEvaluationScoreValue
-			interviewScore = &interviewScoreValue
+			competencyEvaluationScore = generateFloatPointer(0, 100)
+			interviewScore = generateFloatPointer(0, 100)
 
 			firstTestPassYn = stringPointer("YES")
 			secondTestPassYn = nil
 
 		case FINAL_MAJOR:
-			competencyEvaluationScoreValue := randomFloat(0, 100)
-			interviewScoreValue := randomFloat(0, 100)
-
-			competencyEvaluationScore = &competencyEvaluationScoreValue
-			interviewScore = &interviewScoreValue
+			competencyEvaluationScore = generateFloatPointer(0, 100)
+			interviewScore = generateFloatPointer(0, 100)
 
 			firstTestPassYn = stringPointer("YES")
 			secondTestPassYn = stringPointer("YES")
 
 		case RE_EVALUATE:
-			competencyEvaluationScoreValue := randomFloat(0, 100)
-			interviewScoreValue := randomFloat(0, 100)
-
-			competencyEvaluationScore = &competencyEvaluationScoreValue
-			interviewScore = &interviewScoreValue
+			competencyEvaluationScore = generateFloatPointer(0, 100)
+			interviewScore = generateFloatPointer(0, 100)
 
 			firstTestPassYn = stringPointer("YES")
 			secondTestPassYn = stringPointer("NO")
@@ -58,10 +49,10 @@ func GenerateEntranceTestResultInsertQuery(rows int, oneseoStatus OneseoStatus, 
 
 		query := fmt.Sprintf(
 			"INSERT INTO tb_entrance_test_result (competency_evaluation_score, document_evaluation_score, interview_score, entrance_test_factors_detail_id, oneseo_id, first_test_pass_yn, second_test_pass_yn) "+
-				"VALUES (%s, %.2f, %s, %d, %d, %s, %s);",
-			formatNullable(competencyEvaluationScore),
+				"VALUES (%s, %.3f, %s, %d, %d, %s, %s);",
+			formatNullableFloat(competencyEvaluationScore, 0),
 			documentEvaluationScore,
-			formatNullable(interviewScore),
+			formatNullableFloat(interviewScore, 0),
 			i,
 			i,
 			formatNullableString(firstTestPassYn),
@@ -76,11 +67,4 @@ func GenerateEntranceTestResultInsertQuery(rows int, oneseoStatus OneseoStatus, 
 
 func stringPointer(value string) *string {
 	return &value
-}
-
-func formatNullableString(value *string) string {
-	if value == nil {
-		return "NULL"
-	}
-	return fmt.Sprintf("'%s'", *value)
 }

--- a/cmd/generate-dml/generate-middle-school-achievement.go
+++ b/cmd/generate-dml/generate-middle-school-achievement.go
@@ -60,7 +60,7 @@ func GenerateMiddleSchoolAchievementInsertQuery(rows int, graduateStatuses []Gra
 			liberalSystem = "'자유학년제'"
 
 		case GED:
-			gedAvgScore = fmt.Sprintf("%s%.2f%s", "'", rand.Float64()*40+60, "'")
+			gedAvgScore = fmt.Sprintf("%s%.2f%s", "'", *generateFloatPointer(60, 100), "'")
 			absentDays = "NULL"
 			achievement_2_1 = "NULL"
 			achievement_2_2 = "NULL"

--- a/cmd/generate-dml/number-utils.go
+++ b/cmd/generate-dml/number-utils.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"fmt"
+	"math/rand"
+)
+
+func generateFloatPointer(min, max float64) *float64 {
+	floatValue := min + (max-min)*rand.Float64()
+	return &floatValue
+}
+func generateIntPointer(min, max int) *int {
+	intValue := rand.Intn(max-min+1) + min
+	return &intValue
+}
+func formatNullableFloat(value *float64, scale int) string {
+	if value == nil {
+		return "NULL"
+	}
+	format := fmt.Sprintf("%%.%df", scale)
+	return fmt.Sprintf(format, *value)
+}
+func formatNullableString(value *string) string {
+	if value == nil {
+		return "NULL"
+	}
+	return fmt.Sprintf("'%s'", *value)
+}

--- a/cmd/generate-dml/number-utils.go
+++ b/cmd/generate-dml/number-utils.go
@@ -9,10 +9,6 @@ func generateFloatPointer(min, max float64) *float64 {
 	floatValue := min + (max-min)*rand.Float64()
 	return &floatValue
 }
-func generateIntPointer(min, max int) *int {
-	intValue := rand.Intn(max-min+1) + min
-	return &intValue
-}
 func formatNullableFloat(value *float64, scale int) string {
 	if value == nil {
 		return "NULL"


### PR DESCRIPTION
https://github.com/themoment-team/hellogsm-server-24/pull/259 PR에서 입학요강에 맞게 실수형의 소수점 자리수가 2에서 3으로 변경되어, 해당 레포에서도 두자리 소수점으로 생성되던 점수들을, 소수점 세자리까지 표현하도록 변경하였습니다.

기존코드에서 소수점 자리수, 학기별 배점만 바꾼것으로, 여전히 정확한 점수 생성을 보장하지는 않습니다.